### PR TITLE
Fix slider frame element not getting all height that it has available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Slider frame wasn't getting all the height available for him.
+- Slider frame element not getting all height that it has available.
 
 ## [0.2.0] - 2019-02-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.1] - 2019-02-27
 ### Fixed
 - Slider frame element not getting all height that it has available.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Slider frame wasn't getting all the height available for him.
 
 ## [0.2.0] - 2019-02-27
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "slider",
   "vendor": "vtex",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "title": "VTEX Slider",
   "description": "A React Slider component that works well in SPA and SSR",
   "mustUpdateAt": "2020-01-30",

--- a/react/components/Slider.js
+++ b/react/components/Slider.js
@@ -504,7 +504,7 @@ class Slider extends Component {
         >
           <EventListener target="window" onResize={this.handleResize} />
           <SliderFrameTag
-            className={classnames(classes.sliderFrame, styles.sliderFrame, 'list pa0 h-100 ma0 inline-flex')}
+            className={classnames(classes.sliderFrame, styles.sliderFrame, 'list pa0 h-100 ma0 flex')}
             style={firstRender ? { width: `${100 * newChildren.length / this.perPage}%` } : {}}
             ref={this._sliderFrame}
           >


### PR DESCRIPTION
#### What is the purpose of this pull request? What problem is this solving?

As title says

#### How should this be manually tested?
[Workspace](https://fixsliderframe--storecomponents.myvtex.com/)

#### Screenshots or example usage
That's the available space that slider frame element has
![captura de tela de 2019-02-27 15-53-51](https://user-images.githubusercontent.com/8517023/53515663-4f8c7580-3aa9-11e9-9360-ba289a9634bf.png)

That's what it is getting
![captura de tela de 2019-02-27 15-54-00](https://user-images.githubusercontent.com/8517023/53515696-66cb6300-3aa9-11e9-969f-958743ac90fe.png)


#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
