### PR TITLE
Single slide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.3] - 2019-03-13
 ### Fixed
 - Add events and rendering arrows and dots when there is only one slide.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Adding events and rendering arrows and dots when there is only one slide.
 
 ## [0.3.2] - 2019-03-13
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Adding events and rendering arrows and dots when there is only one slide.
+- Add events and rendering arrows and dots when there is only one slide.
 
 ## [0.3.2] - 2019-03-13
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "slider",
   "vendor": "vtex",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "title": "VTEX Slider",
   "description": "A React Slider component that works well in SPA and SSR",
   "mustUpdateAt": "2020-01-30",

--- a/react/components/Dots.js
+++ b/react/components/Dots.js
@@ -106,6 +106,10 @@ class Dots extends PureComponent {
       ...classesProp
     }
 
+    if (totalSlides < 2) {
+      return null
+    }
+
     if (!this.perPage) {
       this.perPage = resolveSlidesNumber(perPage)
     }

--- a/react/components/Slider.js
+++ b/react/components/Slider.js
@@ -109,7 +109,7 @@ class Slider extends PureComponent {
   }
 
   componentDidUpdate() {
-    const { draggable, currentSlide, easing, duration, cursor, children } = this.props
+    const { draggable, currentSlide, easing, duration, cursor } = this.props
 
     this.setSelectorWidth()
     this.setInnerElements()
@@ -118,7 +118,7 @@ class Slider extends PureComponent {
     setStyle(this._sliderFrame.current, {
       ...getStylingTransition(easing, duration),
       width: `${this.totalSlides / this.perPage * 100}%`,
-      ...(draggable && React.Children.count(children) > 1 ? { cursor } : {}),
+      ...(draggable && this.totalSlides > 1 ? { cursor } : {}),
     })
     this._sliderFrameWidth = this._sliderFrame.current.getBoundingClientRect().width
 
@@ -397,14 +397,14 @@ class Slider extends PureComponent {
       ...Slider.defaultProps.classes,
       ...classesProp
     }
-    const childrenLength = React.Children.count(children)
+
     return (
       <Fragment>
-        {1 < childrenLength && this.renderArrows()}
+        {1 < this.totalSlides && this.renderArrows()}
         <RootTag
           className={classnames(classes.root, 'overflow-hidden h-100')}
           ref={this._selector}
-          {...(1 < childrenLength ? Slider.events.reduce((props, event) => ({ ...props, [event]: this[event] }), {}) : {})}
+          {...(1 < this.totalSlides ? Slider.events.reduce((props, event) => ({ ...props, [event]: this[event] }), {}) : {})}
         >
           <EventListener target="window" onResize={this.handleResize} />
           <SliderFrameTag

--- a/react/components/Slider.js
+++ b/react/components/Slider.js
@@ -109,7 +109,7 @@ class Slider extends PureComponent {
   }
 
   componentDidUpdate() {
-    const { draggable, currentSlide, easing, duration, cursor } = this.props
+    const { draggable, currentSlide, easing, duration, cursor, children } = this.props
 
     this.setSelectorWidth()
     this.setInnerElements()
@@ -118,7 +118,7 @@ class Slider extends PureComponent {
     setStyle(this._sliderFrame.current, {
       ...getStylingTransition(easing, duration),
       width: `${this.totalSlides / this.perPage * 100}%`,
-      ...(draggable ? { cursor } : {}),
+      ...(draggable && React.Children.count(children) > 1 ? { cursor } : {}),
     })
     this._sliderFrameWidth = this._sliderFrame.current.getBoundingClientRect().width
 
@@ -397,14 +397,14 @@ class Slider extends PureComponent {
       ...Slider.defaultProps.classes,
       ...classesProp
     }
-
+    const childrenLength = React.Children.count(children)
     return (
       <Fragment>
-        {this.renderArrows()}
+        {1 < childrenLength && this.renderArrows()}
         <RootTag
           className={classnames(classes.root, 'overflow-hidden h-100')}
           ref={this._selector}
-          {...Slider.events.reduce((props, event) => ({ ...props, [event]: this[event] }), {})}
+          {...(1 < childrenLength ? Slider.events.reduce((props, event) => ({ ...props, [event]: this[event] }), {}) : {})}
         >
           <EventListener target="window" onResize={this.handleResize} />
           <SliderFrameTag

--- a/react/components/Slider.js
+++ b/react/components/Slider.js
@@ -400,11 +400,11 @@ class Slider extends PureComponent {
 
     return (
       <Fragment>
-        {1 < this.totalSlides && this.renderArrows()}
+        {this.totalSlides > 1 && this.renderArrows()}
         <RootTag
           className={classnames(classes.root, 'overflow-hidden h-100')}
           ref={this._selector}
-          {...(1 < this.totalSlides ? Slider.events.reduce((props, event) => ({ ...props, [event]: this[event] }), {}) : {})}
+          {...(this.totalSlides > 1 ? Slider.events.reduce((props, event) => ({ ...props, [event]: this[event] }), {}) : {})}
         >
           <EventListener target="window" onResize={this.handleResize} />
           <SliderFrameTag


### PR DESCRIPTION
#### What is the purpose of this pull request? What problem is this solving?

When there is only one slide, it should not have any arrow or dots, or even add events of the slider to `sliderFrame`.

#### How should this be manually tested?
[Workspace with a single slide](https://singlebanner--storecomponents.myvtex.com/)
[Workspace with multiple slides](https://multipleslides--storecomponents.myvtex.com/)

#### Screenshots or example usage
![Captura de tela de 2019-03-13 09-30-28](https://user-images.githubusercontent.com/8517023/54278879-73a08a00-4572-11e9-948e-ae5c9d206f87.png)


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [X] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
