### PR TITLE
Fix condition of sliderFrame size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Condition on `width` of `sliderFrame` when there is less items than the number of itens to show per page.
 
 ## [0.5.1] - 2019-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.5.2] - 2019-04-10
 ### Fixed
 - Condition on `width` of `sliderFrame` when there is less items than the number of itens to show per page.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "slider",
   "vendor": "vtex",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "title": "VTEX Slider",
   "description": "A React Slider component that works well in SPA and SSR",
   "mustUpdateAt": "2020-01-30",

--- a/react/components/Slider.js
+++ b/react/components/Slider.js
@@ -189,7 +189,6 @@ class Slider extends PureComponent {
     this.setSelectorWidth()
     this.setInnerElements()
     this.perPage = resolveSlidesNumber(this.props.perPage)
-    console.log('perPage', this.perPage, this.props.perPage)
     this._sliderFrameWidth = this._sliderFrame.current.getBoundingClientRect().width
   }
 
@@ -212,7 +211,6 @@ class Slider extends PureComponent {
   fit = () => {
     const { perPage, currentSlide, onChangeSlide } = this.props
     this.perPage = resolveSlidesNumber(perPage)
-    console.log('perPage', this.perPage, this.props.perPage)
     const newCurrentSlide =
       Math.floor(currentSlide / this.perPage) * this.perPage
 

--- a/react/components/Slider.js
+++ b/react/components/Slider.js
@@ -129,6 +129,7 @@ class Slider extends PureComponent {
     this._sliderFrame = React.createRef()
     this._sliderFrameWidth = 0
     this.handleResize = debounce(this.fit, props.resizeDebounce)
+    this.perPage = resolveSlidesNumber(props.perPage)
 
     this.state = {
       firstRender: true,
@@ -188,6 +189,7 @@ class Slider extends PureComponent {
     this.setSelectorWidth()
     this.setInnerElements()
     this.perPage = resolveSlidesNumber(this.props.perPage)
+    console.log('perPage', this.perPage, this.props.perPage)
     this._sliderFrameWidth = this._sliderFrame.current.getBoundingClientRect().width
   }
 
@@ -210,6 +212,7 @@ class Slider extends PureComponent {
   fit = () => {
     const { perPage, currentSlide, onChangeSlide } = this.props
     this.perPage = resolveSlidesNumber(perPage)
+    console.log('perPage', this.perPage, this.props.perPage)
     const newCurrentSlide =
       Math.floor(currentSlide / this.perPage) * this.perPage
 
@@ -525,10 +528,7 @@ class Slider extends PureComponent {
       duration,
       cursor,
     } = this.props
-    const { enableTransition, dragDistance } = this.state
-    if (!this.perPage) {
-      this.perPage = resolveSlidesNumber(this.props.perPage)
-    }
+    const { enableTransition, dragDistance, firstRender } = this.state
 
     const classes = {
       ...Slider.defaultProps.classes,
@@ -536,9 +536,12 @@ class Slider extends PureComponent {
     }
 
     const arrayChildren = React.Children.toArray(children)
+    const sliderFrameWidth =
+      this.perPage < this.childrenLength || firstRender
+        ? (100 * this.totalSlides) / this.perPage
+        : 100
     const sliderFrameStyle = {
-      width: `${(100 * this.totalSlides) /
-        Math.min(this.perPage, this.childrenLength)}%`,
+      width: `${sliderFrameWidth}%`,
       ...(this.isMultiPage &&
         getTranslateProperty(
           (currentSlide / this.totalSlides) * -100 + dragDistance


### PR DESCRIPTION
#### What is the purpose of this pull request? What problem is this solving?

Fix the `width` of `sliderFrame` element when there is less elements than it should show in a page (e.g you have `perPage = 4` but there is only 3 elements to render)

#### How should this be manually tested?
Access the [workspace](https://fixslider--storecomponents.myvtex.com/) (due some problems in render, to test this you have to access the workspace, then click in a product, and go back to the home page)

#### Screenshots or example usage
![Captura de tela de 2019-04-08 15-48-40](https://user-images.githubusercontent.com/8517023/55748677-a032af00-5a15-11e9-8afc-47a50a04bc13.png)


#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
