### PR TITLE
Add support for keyboard control

### DIFF
--- a/react/next/README.md
+++ b/react/next/README.md
@@ -121,6 +121,7 @@ const products = [
 | `classNames` | `ClassNames` | 🚫 | - | Custom classes |
 | `thumbnails` | `Thumbnails` | 🚫 | - | Props for thumbnails |
 | `autoplay` | `AutoplayProps` | 🚫 | - | Props for autoplay |
+| `keyboardControlled`  | `Boolean` | 🚫 | false | If is controlled via keyboard arrows or not |
 
 
 

--- a/react/next/hooks/useKeyboardArrows.ts
+++ b/react/next/hooks/useKeyboardArrows.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react'
+
+//state.domLoaded, state.currentSlide
+const useKeyboardArrows = (
+  onLeft: () => void,
+  onRight: () => void,
+  deps: Array<any>
+) => {
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      event.code === 'ArrowLeft' && onLeft()
+      event.code === 'ArrowRight' && onRight()
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+    }
+  }, deps)
+}
+
+export default useKeyboardArrows

--- a/react/next/hooks/useKeyboardArrows.ts
+++ b/react/next/hooks/useKeyboardArrows.ts
@@ -1,6 +1,11 @@
 import { useEffect } from 'react'
 
-//state.domLoaded, state.currentSlide
+/**
+ * Adds event listener to call passed functions by pressing the left or right arrows
+ * @param onLeft Function that is called on left arrow key press
+ * @param onRight Function that is called on arrow arrow key press
+ * @param deps Dependencies
+ */
 const useKeyboardArrows = (
   onLeft: () => void,
   onRight: () => void,

--- a/react/next/index.tsx
+++ b/react/next/index.tsx
@@ -12,6 +12,7 @@ import SlideList from './components/SlideList'
 import Thumbnails from './components/Thumbnails'
 import useControlledTimeout from './hooks/useControlledTimeout'
 import useHovering from './hooks/useHovering'
+import useKeyboardArrows from './hooks/useKeyboardArrows'
 
 /**
  * Slider's main component
@@ -135,6 +136,9 @@ const SliderNext: FC<SliderProps> = props => {
   const prev = () => {
     populate('prev')
   }
+
+  props.keyboardControlled &&
+    useKeyboardArrows(prev, next, [state.domLoaded, state.currentSlide])
 
   /** Go to any slide by index */
   const goToSlide = (slide: number): void => {
@@ -299,6 +303,7 @@ SliderNext.defaultProps = {
     delay: 0,
     timing: 'ease-in-out',
   },
+  keyboardControlled: true,
 }
 
 export default SliderNext

--- a/react/next/index.tsx
+++ b/react/next/index.tsx
@@ -303,7 +303,7 @@ SliderNext.defaultProps = {
     delay: 0,
     timing: 'ease-in-out',
   },
-  keyboardControlled: true,
+  keyboardControlled: false,
 }
 
 export default SliderNext

--- a/react/next/typings/global.d.ts
+++ b/react/next/typings/global.d.ts
@@ -85,6 +85,8 @@ interface SliderProps {
     /** If should stop the timeout by hovering the slide */
     stopOnHover?: boolean
   }
+  /** If is controlled via keyboard arrows or not */
+  keyboardControlled?: boolean
 }
 
 interface SliderState {


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

#### What problem is this solving?
The user may want to control the slider using the keyboard arrows.


#### How should this be manually tested?
Linked @ [workspace](https://thanos--storecomponents.myvtex.com/).
Try to use your left and right arrows to control the slider.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Requires change to documentation, which has been updated accordingly.
