### PR TITLE
Fix/slides stretching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent slides from stretching (and center them) if the total number of items is smaller than the number of items visible per page.
 
 ## [0.5.7] - 2019-07-08
 ### Fixed

--- a/react/components/Slider.js
+++ b/react/components/Slider.js
@@ -504,7 +504,9 @@ class Slider extends PureComponent {
     return React.cloneElement(child, {
       style: {
         ...(child.props.style ? child.props.style : {}),
-        width: `${100 / this.totalSlides}%`,
+        width: this.isMultiPage
+          ? `${100 / this.totalSlides}%`
+          : `${100 / this.perPage}%`,
       },
     })
   }
@@ -571,6 +573,7 @@ class Slider extends PureComponent {
             className={classnames(
               classes.sliderFrame,
               styles.sliderFrame,
+              { 'justify-center': !this.isMultiPage },
               'list pa0 h-100 ma0 flex'
             )}
             style={sliderFrameStyle}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Prevent slides from stretching (and center them) if the total number of items is smaller than the number of items visible per page.

Before: https://storetheme.vtex.com/classy--sunglasses/p (look at the shelf below)
After: https://lbebber--storecomponents.myvtex.com/st-tropez-shorts/p

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
