### PR TITLE
Bugfix/slider centered on mobile

### DIFF
--- a/react/__tests__/__snapshots__/Slider.test.js.snap
+++ b/react/__tests__/__snapshots__/Slider.test.js.snap
@@ -17,7 +17,7 @@ exports[`<Slider /> component should match snapshot 1`] = `
   >
     <ul
       class="sliderFrame list pa0 h-100 ma0 flex"
-      style="width: 400%; transform: translate3d(-18.75%, 0, 0); transition: all 0ms ease-out; cursor: default;"
+      style="width: 400%; transform: translate3d(0, 0, 0); transition: all 0ms ease-out; cursor: default;"
     >
       <li
         class="inline-flex h-100 relative overflow-hidden"

--- a/react/__tests__/__snapshots__/SliderContainer.test.js.snap
+++ b/react/__tests__/__snapshots__/SliderContainer.test.js.snap
@@ -13,7 +13,7 @@ exports[`<SliderContainer /> component should match snapshot 1`] = `
     >
       <ul
         class="sliderFrame list pa0 h-100 ma0 flex"
-        style="width: 200%; transform: translate3d(-37.5%, 0, 0); transition: all 0ms ease-out; cursor: default;"
+        style="width: 200%; transform: translate3d(0, 0, 0); transition: all 0ms ease-out; cursor: default;"
       >
         <li
           class="inline-flex h-100 relative overflow-hidden"
@@ -54,7 +54,7 @@ exports[`<SliderContainer /> component should match snapshot with another tag 1`
     >
       <ul
         class="sliderFrame list pa0 h-100 ma0 flex"
-        style="width: 200%; transform: translate3d(-37.5%, 0, 0); transition: all 0ms ease-out; cursor: default;"
+        style="width: 200%; transform: translate3d(0, 0, 0); transition: all 0ms ease-out; cursor: default;"
       >
         <li
           class="inline-flex h-100 relative overflow-hidden"

--- a/react/components/Slider.js
+++ b/react/components/Slider.js
@@ -552,7 +552,8 @@ class Slider extends PureComponent {
       minPerPage,
     } = this.props
     const { enableTransition, dragDistance, firstRender } = this.state
-    const shouldCenterSlideOnMobile = !Number.isInteger(minPerPage)
+    const shouldCenterSlideOnMobile =
+      minPerPage && !Number.isInteger(minPerPage)
     const CURRENT_SLIDE_CENTER_SHIFT =
       isMobile && shouldCenterSlideOnMobile ? 0.75 : 0
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix a bug caused by not checking whether or not `minPerPage` variable on https://github.com/vtex-apps/slider/blob/bugfix/slider-centered-on-mobile/react/components/Slider.js#L556 is truthy.

#### What problem is this solving?

This fixes an issue where the Slider would center the current slide adding a `0.75` shift to it even though the `minPerPage` variable was an Integer value.

This bug happened when the Slider was being used by the Carousel component because this component is rerendered multiple times before it is actually read to be interacted with, and in the first render, the `minPerPage` was `undefined`, that caused `shouldCenterSlideOnMobile` to be `true` regardless of the other conditions.

#### How should this be manually tested?

https://sliderdebug--worldwidegolf.myvtex.com/

#### Screenshots or example usage

**Before**

<img width="378" alt="Screen Shot 2019-08-18 at 10 54 14 AM" src="https://user-images.githubusercontent.com/27777263/63225453-a5afbb00-c1a6-11e9-954a-6cf017df2849.png">


**After**

<img width="377" alt="Screen Shot 2019-08-18 at 10 54 54 AM" src="https://user-images.githubusercontent.com/27777263/63225457-ad6f5f80-c1a6-11e9-85bc-70b8b644b61f.png">


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
