### PR TITLE
Prevents call event.preventDefault when the event target is select from SKU Selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Check to prevent call event preventDefault when the target is the sku selector.
 
 ## [0.8.2] - 2020-08-20
 ### Changed

--- a/react/components/Slider.js
+++ b/react/components/Slider.js
@@ -457,7 +457,14 @@ class Slider extends PureComponent {
 
   onMouseDown = e => {
     const { cursorOnMouseDown } = this.props
-    e.preventDefault()
+
+    /** this check avoid call the preventDefault when the event was triggered by SKU-selector with mode selector inside the product-summary.
+     * <Link the sku selector here>
+     */
+    if (e.target.name !== 'product-summary-sku-selector') {
+      e.preventDefault()
+    }
+
     this.pointerDown = true
     this.drag.startX = e.pageX
 
@@ -483,6 +490,7 @@ class Slider extends PureComponent {
   onMouseMove = e => {
     const { currentSlide, draggable, cursorOnMouseDown } = this.props
     e.preventDefault()
+
     if (this.pointerDown && draggable) {
       // TODO prevent link clicks
       this.drag.endX = e.pageX

--- a/react/components/Slider.js
+++ b/react/components/Slider.js
@@ -458,8 +458,9 @@ class Slider extends PureComponent {
   onMouseDown = e => {
     const { cursorOnMouseDown } = this.props
 
-    /** this check avoid call the preventDefault when the event was triggered by SKU-selector with mode selector inside the product-summary.
-     * https://github.com/vtex-apps/store-components/pull/958
+    /** 
+     * This check avoids calling the preventDefault when the event was triggered by SKU-selector with mode selector inside a product-summary.
+     * Further details at https://github.com/vtex-apps/store-components/pull/958.
      */
     if (e.target.name !== 'product-summary-sku-selector') {
       e.preventDefault()

--- a/react/components/Slider.js
+++ b/react/components/Slider.js
@@ -459,7 +459,7 @@ class Slider extends PureComponent {
     const { cursorOnMouseDown } = this.props
 
     /** this check avoid call the preventDefault when the event was triggered by SKU-selector with mode selector inside the product-summary.
-     * <Link the sku selector here>
+     * https://github.com/vtex-apps/store-components/pull/958
      */
     if (e.target.name !== 'product-summary-sku-selector') {
       e.preventDefault()

--- a/react/package.json
+++ b/react/package.json
@@ -27,6 +27,6 @@
     "eslint-config-vtex-react": "^4.0.0",
     "jsdom": "^14.0.0",
     "prettier": "^1.16.4",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4955,10 +4955,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typescript@^3.3.3333:
   version "3.7.4"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Avoid calling event preventDefault when the event target is a ProductSummarySKUSelector.

#### What problem is this solving?
Fix a bug that the ProductSummarySKUSelector on mode `select` doesn't open the select dropdown due to that event is default prevented inside the `onMouseDown` function from the slider with multiples pages.

#### How should this be manually tested?
[Fixed workspace](https://brasileirovtex--dacris.myvtex.com/marker-pentru-tabla-pilot-vboard-master-varf-rotund-2-3-mm/p?__bindingAddress=www.dacris.net/)
[Production workspace](https://dacris.myvtex.com/marker-pentru-tabla-pilot-vboard-master-varf-rotund-2-3-mm/p?__bindingAddress=www.dacris.net/)

Steps:
1. Select a product summary list with more than one page;
2. Click on the SKU selector dropdown;
3. Check if the select options appear.

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
